### PR TITLE
[del-5544]: delete delegate service

### DIFF
--- a/harness-delegate-ng/templates/service.yaml
+++ b/harness-delegate-ng/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: delegate-service
+  name: {{ template "harness-delegate-ng.fullname" . }}-delegate-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}


### PR DESCRIPTION
Remove delegate-service.
This kubernetes resources is not name prefixed with delegate name, thus it blocks customers from creating multiple delegate releases in the same namespace (using helm).

Tests are done:
`helm install test-helm   harness-delegate-ng --set delegateName=test-helm \
--set accountId=px7xd_BFRCi-pfWPYXVjvw \
--set delegateToken=7c4f3d9e09a2ed729751f0a6385f8405 \
--set managerEndpoint=https://qa.harness.io --set delegateDockerImage=harness/delegate:22.11.77611
`

<img width="1157" alt="Screen Shot 2022-12-09 at 1 15 41 PM" src="https://user-images.githubusercontent.com/109999795/206797404-02a26fce-06bf-4809-973e-b12f1703252f.png">
<img width="1420" alt="Screen Shot 2022-12-09 at 1 17 54 PM" src="https://user-images.githubusercontent.com/109999795/206797629-9893e06d-8ce2-4c5d-a3a6-8a501be79dd2.png">
