### PR TITLE
fix: [DEL-5758]: The token copied from ng UI will be already base64 encoded

### DIFF
--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -8,4 +8,4 @@ metadata:
 type: Opaque
 data:
   # Base 64 encoded account secret
-  DELEGATE_TOKEN: {{ .Values.delegateToken | b64enc | quote }}
+  DELEGATE_TOKEN: {{ .Values.delegateToken | quote }}


### PR DESCRIPTION
As part of https://github.com/harness/harness-core/pull/42545, Token copied is already base64 encoded.

Verified with helm dry run and checked the output. 