### PR TITLE
Revert "fix: [DEL-5758]: The token copied from ng UI will be already base64 encoded"

### DIFF
--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -8,4 +8,4 @@ metadata:
 type: Opaque
 data:
   # Base 64 encoded account secret
-  DELEGATE_TOKEN: {{ .Values.delegateToken | quote }}
+  DELEGATE_TOKEN: {{ .Values.delegateToken | b64enc | quote }}


### PR DESCRIPTION
Reverts harness/delegate-helm-chart#12

Description:
With the newly discussed release plan, documented here https://harness.atlassian.net/wiki/spaces/DEL/pages/21296022393/Release+strategy+for+Install+UI+Base64+token+changes
We will take approach two, in which Helm chart will have no change. 

Test:
We have verified all the combinations in pre-QA and PR, the test results are in https://harness.atlassian.net/wiki/spaces/DEL/pages/21291469166/Base64+Token+changes+Validation+Details 