### PR TITLE
fix: [DEL-6030]: fix difference between helm value and the k8s file in manager

### DIFF
--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -54,13 +54,13 @@ pollForTasks: "false"
 
 # Change this to alter startup probe and liveness probe settings
 startupProbe:
-  initialDelaySeconds: 10
+  initialDelaySeconds: 30
   periodSeconds: 10
-  failureThreshold: 40
+  failureThreshold: 15
 
 livenessProbe:
-  initialDelaySeconds: 30
-  periodSeconds: 20
+  initialDelaySeconds: 10
+  periodSeconds: 10
   failureThreshold: 3
 
 # Add delegate description and tags


### PR DESCRIPTION
The startup/liveness prob settings are different from the one in manager
https://github.com/harness/harness-core/blob/develop/400-rest/src/main/resources/delegatetemplates/harness-delegate-ng-immutable.yaml.ftl#L93 
I am changing everywhere to be 

```
startupProbe:
  initialDelaySeconds: 30
  periodSeconds: 10
  failureThreshold: 15

livenessProbe:
  initialDelaySeconds: 10
  periodSeconds: 10
  failureThreshold: 3

```
