### PR TITLE
Add Support for Custom Shared Certificates, Custom Envs, Custom VolumeMounts, and Custom Volumes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.tf]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[Makefile*]
+indent_style = tab

--- a/harness-delegate-ng/Chart.yaml
+++ b/harness-delegate-ng/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -88,4 +88,16 @@ Memory assigned to container in Mi
   {{- printf "%s%s" $allocatedRam "Mi" }}
 {{- end }}
 
+{{/*
+Generate a list of default certificate path with certificate target location
+*/}}
+{{- define "certificate_mount_volumes" -}}
 
+  {{- $default_certs_path := .certs_path }}
+  {{- $mount_volumes := list -}}
+
+  {{- range .ci_mount_targets }}
+    {{- $mount_volumes = append $mount_volumes (printf "%s:%s" $default_certs_path .) -}}
+  {{- end }}
+  {{- join "," $mount_volumes -}}
+{{- end }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if and $.Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets }}
+          {{- if $.Values.shared_certificates.ca_bundle }}
             - name: certvol
               mountPath: {{ .Values.shared_certificates.certs_path }}
               subPath:  ca.bundle
@@ -89,7 +89,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-      {{- if and $.Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets }}
+      {{- if $.Values.shared_certificates.ca_bundle }}
         - name: certvol
           secret:
             secretName: {{ template "harness-delegate-ng.fullname" . }}-addcerts

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -72,6 +72,34 @@ spec:
             - secretRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}-proxy
                 optional: true
+            - configMapRef:
+                name: {{ template "harness-delegate-ng.fullname" . }}-shared-certificates
+                optional: true
+          {{- with .Values.custom_envs }}
+          envs:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if and $.Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets }}
+            - name: certvol
+              mountPath: {{ .Values.shared_certificates.certs_path }}
+              subPath:  ca.bundle
+          {{- end }}
+          {{- with .Values.custom_mounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+      {{- if and $.Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets }}
+        - name: certvol
+          secret:
+            secretName: {{ template "harness-delegate-ng.fullname" . }}-addcerts
+            items:
+            - key: ca.bundle
+              path: ca.bundle
+      {{- end }}
+      {{- with .Values.custom_volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
@@ -1,0 +1,17 @@
+
+{{- if and .Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-shared-certificates
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+data:
+  {{- with .Values.shared_certificates }}
+  ADDITIONAL_CERTS_PATH: {{ .certs_path }}
+  {{ if .ci_mount_targets -}}
+  CI_MOUNT_VOLUMES: {{ template "certificate_mount_volumes" . }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
@@ -1,5 +1,4 @@
-
-{{- if and .Values.shared_certificates.enabled .Values.shared_certificates.ci_mount_targets -}}
+{{- if .Values.shared_certificates.ci_mount_targets -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.shared_certificates.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-addcerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca.bundle: {{ .Values.shared_certificates.ca_bundle | b64enc | quote }}
+{{- end }}

--- a/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.shared_certificates.enabled -}}
+{{- if .Values.shared_certificates.ca_bundle -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -99,6 +99,10 @@ nextGen: true
 
 # Configure a Kubernetes build farm to use self-signed certificates
 # https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/
+# CAUTION
+# Make sure that the destination path is not same as the default CA certificate path of the corresponding container image.
+#
+# If you want to override the default certificate file, make sure the Kubernetes secret or config map (from step one) includes all certificates required by the pipelines that will use this build infrastructure.
 shared_certificates:
   enabled: false
   certs_path: /shared/customer-artifacts/certificates/ca.bundle

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -104,10 +104,13 @@ nextGen: true
 #
 # If you want to override the default certificate file, make sure the Kubernetes secret or config map (from step one) includes all certificates required by the pipelines that will use this build infrastructure.
 shared_certificates:
-  enabled: false
+  # Location in the delegate to which the ca_bundle will be mounted or a location in the custom delegate image to which the
+  # CA chain has already been placed as part of creating the custom delegate image
   certs_path: /shared/customer-artifacts/certificates/ca.bundle
   # Example Certificate Chain (Multi-line files )
   # ca_bundle should be the text of the CA Bundle to include in a secret
+  #
+  # Note: when defined, the secret will be mounted to the certs_path location on the delegate
   ca_bundle: # |
   #   -----BEGIN CERTIFICATE-----
   #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -116,7 +119,8 @@ shared_certificates:
   #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
   #   -----END CERTIFICATE-------
 
-  # CI Mount targets are the locations that the secrets should be mounted in the CI Images
+  # CI Mount targets are the locations that the secrets should be mounted in the CI Images.  This will share any CA chain defined in the certs_path key to any CI image
+  # configured in the pod.
   ci_mount_targets:
     # - /etc/ssl/certs/ca-bundle.crt
     # - /etc/ssl/certs/ca-certificates.crt

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -97,3 +97,29 @@ securityContext:
 
 nextGen: true
 
+# Configure a Kubernetes build farm to use self-signed certificates
+# https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/
+shared_certificates:
+  enabled: false
+  certs_path: /shared/customer-artifacts/certificates/ca.bundle
+  # Example Certificate Chain (Multi-line files )
+  # ca_bundle should be the text of the CA Bundle to include in a secret
+  ca_bundle: # |
+  #   -----BEGIN CERTIFICATE-----
+  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
+  #   -----END CERTIFICATE-------
+  #   -----BEGIN CERTIFICATE-----
+  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
+  #   -----END CERTIFICATE-------
+
+  # CI Mount targets are the locations that the secrets should be mounted in the CI Images
+  ci_mount_targets:
+    # - /etc/ssl/certs/ca-bundle.crt
+    # - /etc/ssl/certs/ca-certificates.crt
+    # - /kaniko/ssl/certs/additional-ca-cert-bundle.crt
+
+custom_envs:
+
+custom_mounts:
+
+custom_volumes:


### PR DESCRIPTION
Added support to include a mounted shared certificate trust chain
Added support for Custom Envs, VolumeMounts, and Volumes

Documentation detailing process to include custom shared certificate trust chains:
https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/