### PR TITLE
Provide way to have extra env vars

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- if .Values.extraEnvVars }}
+          env:
+{{ toYaml .Values.extraEnvVars | indent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -97,3 +97,4 @@ securityContext:
 
 nextGen: true
 
+extraEnvVars: []


### PR DESCRIPTION
Our scenario, we have many delegate which are installed from a composition of values per environment.

We plan to export some variables to be used at the Init_script and make it a bit more dynamic. 