### PR TITLE
Provide unique Service per helm release

### DIFF
--- a/harness-delegate-ng/templates/service.yaml
+++ b/harness-delegate-ng/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: delegate-service
+  name: {{ include "harness-delegate-ng.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}


### PR DESCRIPTION
We have scenario where we install more than 1 delegate in the same namespace but with different access levels, but the k8s Service makes a conflict with them.