### PR TITLE
fix: [PL-38283]: increase wait time during rolling upgrade

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
     matchLabels:
       {{- include "harness-delegate-ng.selectorLabels" . | nindent 6 }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -131,3 +131,7 @@ custom_envs:
 custom_mounts:
 
 custom_volumes:
+
+# minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.
+# This is set for improving stability during upgrade. It will tell kubernetes to wait at least this amount of seconds before removing the old pod after the new one becomes ready.
+minReadySeconds: 120


### PR DESCRIPTION
Set minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.
This is set for improving stability during upgrade. It will tell kubernetes to wait at least this amount of seconds before removing the old pod after the new one becomes ready.

Test:
Test required for this PR is same as https://github.com/harness/harness-core/pull/47039 