### PR TITLE
revert chart version to 1.0.9

### DIFF
--- a/harness-delegate-ng/Chart.yaml
+++ b/harness-delegate-ng/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/harness-delegate-ng/README.md
+++ b/harness-delegate-ng/README.md
@@ -16,6 +16,8 @@ This chart is only compatible with helm version >= 3.2
 $ helm repo add harness-delegate https://app.harness.io/storage/harness-download/delegate-helm-chart
 ```
 
+Note: Older helm chart repo: https://app.harness.io/storage/harness-download/harness-helm-charts is DEPRECATED and receives no further update, please use the new repo mentioned above.
+
 The chart requires some account specific information. To install harness delegate using helm chart go to delegates page in harness UI
 and click on install delegate using helm chart. Follow on screen instructions to install harness-delegate using helm.
 


### PR DESCRIPTION
reverting chart version to 1.0.9 from 1.0.10 because we longer manually update version in chart.yaml. 
Version in chart.yaml is updated by pipeline at the time of release. 
https://harness.atlassian.net/wiki/spaces/DEL/pages/21267447835/Publishing+Delegate+Helm+Chart+in+NG