### PR TITLE
Bug fixes in helm chart.

### DIFF
--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   ACCOUNT_ID: {{ .Values.accountId }}
   MANAGER_HOST_AND_PORT : {{ .Values.managerEndpoint }}
-  DEPLOY_MODE: "KUBERNETES"
+  DEPLOY_MODE: {{ .Values.deployMode }}
   DELEGATE_NAME: {{ .Values.delegateName | quote }}
   POLL_FOR_TASKS: {{ .Values.pollForTasks | quote }}
   NEXT_GEN: {{ .Values.nextGen | quote }}

--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
 data:
-  ACCOUNT_ID: {{ required "A valid .Values.accountId entry required!" .Values.accountId }}
+  ACCOUNT_ID: {{ .Values.accountId }}
   MANAGER_HOST_AND_PORT : {{ .Values.managerEndpoint }}
   DEPLOY_MODE: "KUBERNETES"
   DELEGATE_NAME: {{ .Values.delegateName | quote }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                 name: {{ template "harness-delegate-ng.fullname" . }}-shared-certificates
                 optional: true
           {{- with .Values.custom_envs }}
-          envs:
+          env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -42,6 +42,8 @@ delegateToken: ""
 
 delegateName: harness-delegate-ng
 
+deployMode: "KUBERNETES"
+
 delegateDockerImage: ""
 
 imagePullSecret: ""


### PR DESCRIPTION
Changes:
1- Make accountID not mandatory so that customers can run helm template without accountId mentioned.
2- Correct envs -> env in deployment.yaml
3- Make deployMode configurable with default value KUBERNETES, this is done so that in on-prem system we can override it with KUBERNETES_ONPREM

Testing:
1- helm template doesn't throw error when accountId is not mentioned.
2- Installed helm delegate on ng smp test and it came up.

JIRA: 
https://harness.atlassian.net/browse/PL-38918 
https://harness.atlassian.net/browse/SMP-1368
https://harness.atlassian.net/browse/PL-38919