### PR TITLE
Fix: [PL-39737]: Moving hpa version from v2/beta1 to v2

### DIFF
--- a/harness-delegate-ng/templates/hpa.yaml
+++ b/harness-delegate-ng/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "harness-delegate-ng.fullname" . }}
@@ -18,12 +18,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -33,13 +33,6 @@ tolerations: []
 
 affinity: {}
 
-# Account Id to which the delegate will be connecting
-accountId: ""
-# Account Secret
-accountSecret: ""
-# Delegate Token
-delegateToken: ""
-
 delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
@@ -98,6 +91,14 @@ securityContext:
   runAsRoot: true
 
 nextGen: true
+
+# Below are the required fields, no default values are populated for these.
+# Please add values for delegate to work.
+
+# Account Id to which the delegate will be connecting
+accountId: ""
+# Delegate Token
+delegateToken: ""
 
 # Configure a Kubernetes build farm to use self-signed certificates
 # https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/


### PR DESCRIPTION
Testing:
1- Tested delegate using hpa based on memory and cpu with max replica 2.

<img width="1259" alt="Screenshot 2023-07-03 at 12 00 04 PM" src="https://github.com/harness/delegate-helm-chart/assets/102655013/b5eae928-2f03-4da9-8697-975374343b8b">
