### PR TITLE
making docker image as empty in values.yaml

### DIFF
--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -37,7 +37,7 @@ delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
 
-delegateDockerImage: harness/delegate:23.05.79310
+delegateDockerImage: ""
 
 imagePullSecret: ""
 


### PR DESCRIPTION
This is required because we update this using pipeline at the chart release.

In script use in pipeline we search for empty dockerImage and then replace it with mentioned version. If dockerImage is not empty we will not be able to find it hence image will not be updated using pipeline.

Script snippet that we use
```
stringToModify='delegateDockerImage: '
repo='harness/delegate'
delegateImageTag=$repo:$DELEGATE_VERSION
versionString='version: '
actualString='delegateDockerImage: ""'
replacedString=$stringToModify$delegateImageTag

# update values.yaml file
sed -i -e "s|${actualString}|${replacedString}|g" values.yaml
```