### PR TITLE
Feat: [CCM-13259]: Add CCM Visibility Role

### DIFF
--- a/harness-delegate-ng/templates/ccm/cost-access.yaml
+++ b/harness-delegate-ng/templates/ccm/cost-access.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ccm.enabled }}
+{{- if .Values.ccm.visibility }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/harness-delegate-ng/templates/ccm/cost-access.yaml
+++ b/harness-delegate-ng/templates/ccm/cost-access.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.ccm.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.ccm.role_name }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - nodes/proxy
+      - events
+      - namespaces
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.ccm.role_name }}binding
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.ccm.role_name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "harness-delegate-ng.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/harness-delegate-ng/templates/ccm/cost-access.yaml
+++ b/harness-delegate-ng/templates/ccm/cost-access.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.ccm.visibility }}
+{{- if and (.Values.ccm.visibility) (ne .Values.k8sPermissionsType "CLUSTER_ADMIN")}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.ccm.role_name }}
+  name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibility
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
 rules:
@@ -62,13 +62,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.ccm.role_name }}binding
+  name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibilitybinding
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.ccm.role_name }}
+  name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibility
 subjects:
   - kind: ServiceAccount
     name: {{ include "harness-delegate-ng.serviceAccountName" . }}

--- a/harness-delegate-ng/templates/ccm/cost-access.yaml
+++ b/harness-delegate-ng/templates/ccm/cost-access.yaml
@@ -62,7 +62,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibilitybinding
+  name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibility-roleBinding
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
 roleRef:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -138,3 +138,7 @@ custom_volumes:
 # minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.
 # This is set for improving stability during upgrade. It will tell kubernetes to wait at least this amount of seconds before removing the old pod after the new one becomes ready.
 minReadySeconds: 120
+
+ccm:
+  enabled: false
+  role_name: ccm-visibility-clusterrole

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -139,5 +139,7 @@ custom_volumes:
 # This is set for improving stability during upgrade. It will tell kubernetes to wait at least this amount of seconds before removing the old pod after the new one becomes ready.
 minReadySeconds: 120
 
+# Enable the cluster role needed for CCM cost visibility
+# Not needed if k8sPermissionsType: "CLUSTER_ADMIN" is specified
 ccm:
   visibility: false

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -140,5 +140,5 @@ custom_volumes:
 minReadySeconds: 120
 
 ccm:
-  enabled: false
+  visibility: false
   role_name: ccm-visibility-clusterrole

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -141,4 +141,3 @@ minReadySeconds: 120
 
 ccm:
   visibility: false
-  role_name: ccm-visibility-clusterrole


### PR DESCRIPTION
Adding CCM visibility clusterrole to delegate helm chart.

Why? When new customers are setting up CCM for k8s they have to deploy a delegate first, and then add the cluster visibility role later. This is only given to you in the UI, which leads to issues when infra teams are tasked with rolling out the delegate over many clusters and do not want to go to the harness UI every time.

This gives the customers an easier onboarding flow for enrolling clusters into CCM.

Previous flow:
1. engineer deploys delegate into cluster via helm
2. engineer gets clusterrole yaml from harness owner
2. engineer adds clusterrole yaml into cluster via kubectl

New flow:
1. engineer deploys delegate into cluster via helm - adds ccm value to enable clusterrole