### PR TITLE
[PL-39739]: hpa changes for backward compatibility

### DIFF
--- a/harness-delegate-ng/templates/hpaLegacy.yaml
+++ b/harness-delegate-ng/templates/hpaLegacy.yaml
@@ -1,5 +1,5 @@
-{{- if and (.Values.autoscaling.enabled) (semverCompare ">=1.23.x-0" .Capabilities.KubeVersion.GitVersion) }}
-apiVersion: autoscaling/v2
+{{- if and (.Values.autoscaling.enabled) (semverCompare "<1.23.x-0" .Capabilities.KubeVersion.GitVersion)  }}
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "harness-delegate-ng.fullname" . }}
@@ -18,17 +18,12 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}
-

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -37,7 +37,7 @@ delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
 
-delegateDockerImage: harness/delegate:23.06.79503
+delegateDockerImage: ""
 
 imagePullSecret: ""
 


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/PL-39737
Making HPA backward compatible.

Testing:
1- minikube, k8 cluster version 1.22.16
Bought up delegate and checked.

2- pl-play cluster, k8 version 1.25.x
Bought up delegate and checked.
