### PR TITLE
feat: [PL-38515]: Adding custom annotation support for delegate deployment

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -14,9 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "3460"
-        prometheus.io/path: "/api/metrics"
+        {{- toYaml .Values.annotations | nindent 8 }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
         checksum/configmap: {{ include (print .Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
       labels:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -38,7 +38,14 @@ delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
 
-delegateDockerImage: harness/delegate:23.06.79707
+delegateDockerImage: ""
+
+
+# Annotations for delegate deployment, prometheus is added by default
+annotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "3460"
+  prometheus.io/path: "/api/metrics"
 
 imagePullSecret: ""
 


### PR DESCRIPTION
Adding custom annotation support for delegate deployment

1- To add annotations from override yaml, add your annotation in override.yaml file and apply it.

Example:
annotations:
  abc.io/propery: "true"

2- For adding annotation using command line refer below example:
  --set annotations."prometheus\.io/path"="/api/metrics" \
  --set-string annotations."prometheus\.io/scrape"=true 

Testing:
Installed delegate using.
1- Original delegate with no new changes and prometheus annotations.
2- Delegate with custom annotations using override.yaml 
3- Delegate with custom annotations using command line.

<img width="1029" alt="Screenshot 2023-07-29 at 12 55 05 PM" src="https://github.com/harness/delegate-helm-chart/assets/102655013/86e91c1f-dde1-4a71-aab9-e24037225d3b">

