### PR TITLE
feat: use delegate token from existing secret

### DIFF
--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -101,3 +101,25 @@ Generate a list of default certificate path with certificate target location
   {{- end }}
   {{- join "," $mount_volumes -}}
 {{- end }}
+
+{{/*
+Define the delegate token name
+*/}}
+{{- define "harness-delegate-ng.delegateToken" -}}
+{{- if .Values.delegateToken }}
+{{- include "harness-delegate-ng.fullname" . }}
+{{- else }}
+{{- .Values.existingDelegateToken | trunc 63 | toString }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the upgrader delegate token name
+*/}}
+{{- define "harness-delegate-ng.upgraderDelegateToken" -}}
+{{- if .Values.delegateToken }}
+{{- include "harness-delegate-ng.fullname" . }}-upgrader-token
+{{- else }}
+{{- .Values.existingDelegateToken | trunc 63 | toString }}
+{{- end }}
+{{- end }}

--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -106,7 +106,7 @@ Generate a list of default certificate path with certificate target location
 Define the delegate token name
 */}}
 {{- define "harness-delegate-ng.delegateToken" -}}
-{{- if .Values.delegateToken }}
+{{- if not .Values.existingDelegateToken }}
 {{- include "harness-delegate-ng.fullname" . }}
 {{- else }}
 {{- .Values.existingDelegateToken | trunc 63 | toString }}
@@ -114,12 +114,12 @@ Define the delegate token name
 {{- end }}
 
 {{/*
-Define the upgrader delegate token name
+Define the upgrader token name
 */}}
 {{- define "harness-delegate-ng.upgraderDelegateToken" -}}
-{{- if .Values.delegateToken }}
+{{- if not .Values.upgrader.existingUpgraderToken }}
 {{- include "harness-delegate-ng.fullname" . }}-upgrader-token
 {{- else }}
-{{- .Values.existingDelegateToken | trunc 63 | toString }}
+{{- .Values.upgrader.existingUpgraderToken | trunc 63 | toString }}
 {{- end }}
 {{- end }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - configMapRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}
             - secretRef:
-                name: {{ template "harness-delegate-ng.fullname" . }}
+                name: {{ include "harness-delegate-ng.delegateToken" . }}
             - configMapRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}-proxy
                 optional: true

--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.delegateToken }}
+{{- if not .Values.existingDelegateToken }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.delegateToken }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ type: Opaque
 data:
   # Base 64 encoded account secret
   DELEGATE_TOKEN: {{ .Values.delegateToken | b64enc | quote }}
+{{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -22,7 +22,7 @@ spec:
               imagePullPolicy: Always
               envFrom:
                 - secretRef:
-                    name: {{ .Values.delegateName }}-upgrader-token
+                    name: {{ include "harness-delegate-ng.upgraderDelegateToken" . }}
               volumeMounts:
                 - name: config-volume
                   mountPath: /etc/config

--- a/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.upgrader.enabled -}}
-{{- if .Values.delegateToken -}}
+{{- if not .Values.upgrader.existingUpgraderToken -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.upgrader.enabled -}}
+{{- if .Values.delegateToken -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,5 @@ metadata:
 type: Opaque
 data:
   UPGRADER_TOKEN: {{ .Values.delegateToken | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -109,6 +109,8 @@ nextGen: true
 accountId: ""
 # Delegate Token
 delegateToken: ""
+# Existing secret name with the delegate token variable
+existingDelegateToken: ""
 
 # Configure a Kubernetes build farm to use self-signed certificates
 # https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -95,7 +95,12 @@ upgrader:
   enabled: true
   upgraderDockerImage: "harness/upgrader:latest"
   cronJobServiceAccountName: "upgrader-cronjob-sa"
-  # Existing secret name with UPGRADER_TOKEN key
+  # Use existing Secret which stores UPGRADER_TOKEN key instead of creating a new one. The value should be set with the `UPGRADER_TOKEN` key inside the secret.
+  ## The use of external secrets allows you to manage credentials from external tools like Vault, 1Password, SealedSecrets, among other.
+  ## If set, this parameter takes precedence over "delegateToken"
+  ## Recommendation:
+  ## - Use different Secrets names for `existingUpgraderToken` and `existingDelegateToken`.
+  ## - Do not use same Secrets names in multiple helm deployments.
   existingUpgraderToken: ""
 
 # Delegate is run by default with root access
@@ -111,7 +116,12 @@ nextGen: true
 accountId: ""
 # Delegate Token
 delegateToken: ""
-# Existing secret name with DELEGATE_TOKEN key
+# Use existing Secret which stores DELEGATE_TOKEN key instead of creating a new one. The value should be set with the `DELEGATE_TOKEN` key inside the secret.
+## The use of external secrets allows you to manage credentials from external tools like Vault, 1Password, SealedSecrets, among other.
+## If set, this parameter takes precedence over "delegateToken".
+## Recommendations:
+## - Use different Secrets names for `existingUpgraderToken` and `existingDelegateToken`.
+## - Do not use same Secrets names in multiple helm deployments.
 existingDelegateToken: ""
 
 # Configure a Kubernetes build farm to use self-signed certificates

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -97,10 +97,10 @@ upgrader:
   cronJobServiceAccountName: "upgrader-cronjob-sa"
   # Use existing Secret which stores UPGRADER_TOKEN key instead of creating a new one. The value should be set with the `UPGRADER_TOKEN` key inside the secret.
   ## The use of external secrets allows you to manage credentials from external tools like Vault, 1Password, SealedSecrets, among other.
-  ## If set, this parameter takes precedence over "delegateToken"
+  ## If set, this parameter takes precedence over "upgraderToken"
   ## Recommendation:
   ## - Use different Secrets names for `existingUpgraderToken` and `existingDelegateToken`.
-  ## - Do not use same Secrets names in multiple helm deployments.
+  ## - Do not use Secrets managed by other helm delpoyments.
   existingUpgraderToken: ""
 
 # Delegate is run by default with root access
@@ -121,7 +121,7 @@ delegateToken: ""
 ## If set, this parameter takes precedence over "delegateToken".
 ## Recommendations:
 ## - Use different Secrets names for `existingUpgraderToken` and `existingDelegateToken`.
-## - Do not use same Secrets names in multiple helm deployments.
+## - Do not use Secrets managed by other helm delpoyments.
 existingDelegateToken: ""
 
 # Configure a Kubernetes build farm to use self-signed certificates

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -95,6 +95,8 @@ upgrader:
   enabled: true
   upgraderDockerImage: "harness/upgrader:latest"
   cronJobServiceAccountName: "upgrader-cronjob-sa"
+  # Existing secret name with UPGRADER_TOKEN key
+  existingUpgraderToken: ""
 
 # Delegate is run by default with root access
 securityContext:
@@ -109,7 +111,7 @@ nextGen: true
 accountId: ""
 # Delegate Token
 delegateToken: ""
-# Existing secret name with the delegate token variable
+# Existing secret name with DELEGATE_TOKEN key
 existingDelegateToken: ""
 
 # Configure a Kubernetes build farm to use self-signed certificates


### PR DESCRIPTION
Secrets are managed out of the helm chart lifecycle when secret management tools are in place. Therefore, the chart should bring the option to use existing secrets in the namespace.