### PR TITLE
feat: [PL-40553]: making security context configurable

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -30,10 +30,9 @@ spec:
       containers:
         - name: delegate
           image: {{ .Values.delegateDockerImage }}
-          {{- if .Values.securityContext.runAsRoot }}
           securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          {{- if .Values.securityContext.runAsRoot }}
+            {{- toYaml .Values.delegateSecurityContext | nindent 12 }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
         - name: delegate
           image: {{ .Values.delegateDockerImage }}
-          securityContext:
           {{- if .Values.securityContext.runAsRoot }}
+          securityContext:
             {{- toYaml .Values.delegateSecurityContext | nindent 12 }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -96,9 +96,16 @@ upgrader:
   upgraderDockerImage: "harness/upgrader:latest"
   cronJobServiceAccountName: "upgrader-cronjob-sa"
 
-# Delegate is run by default with root access
+# This field is DEPRECATED, DON'T OVERRIDE/USE THIS!!
+# To set root/non-root access and other security context use delegateSecurityContext field below.
+# Not removing this field to maintain backward compatibility.
 securityContext:
   runAsRoot: true
+
+# Set security context for delegate
+delegateSecurityContext:
+  allowPrivilegeEscalation: false
+  runAsUser: 0
 
 nextGen: true
 


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/PL-40553

1- We need to add delegateSecurityContext to set/override security context for delegate.
2- Need to stop using below to as access as non-root, instead new users should use delegateSecurityContext.
securityContext:
  runAsRoot: false
3- For old users nothing will change, if they want to configure securityContext for delegate they shouldn't use deprecated field:
securityContext:
  runAsRoot: false


Testing:
Bought up delegate with runAsRoot: true/false and delegateSecurityContext.
