### PR TITLE
Make dnsConfig configurable

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -110,3 +110,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -174,3 +174,16 @@ minReadySeconds: 120
 # Not needed if k8sPermissionsType: "CLUSTER_ADMIN" is specified
 ccm:
   visibility: false
+
+dnsConfig: {}
+#  nameservers:
+#    - 1.2.3.4
+#  searches:
+#    - ns1.svc.cluster-domain.example
+#    - my.dns.search.suffix
+#  options:
+#    - name: ndots
+#      value: "2"
+#    - name: edns0
+
+dnsPolicy: ""


### PR DESCRIPTION
- Add functionality to add dnsConfig and dnsPolicy to manifest using override file.

Testing:
- Tested using cloudflare DNS 1.1.1.1, disabled kube-dns using dnsPolicy as none Adding ss below
<img width="1238" alt="Screenshot 2023-11-06 at 2 16 40 PM" src="https://github.com/harness/delegate-helm-chart/assets/102655013/9e30cbac-5efe-4a86-8f83-a2e207fc8d9a">

- Tested with default scenario, i.e without dnsConfig and dnsPolicy and delegate came up fine.