### PR TITLE
feat: [PL-43413]: add support for custom cert in delegate and upgrader

### DIFF
--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -23,5 +23,8 @@ data:
   {{- if not .Values.nextGen }}
   DELEGATE_GROUP_NAME: {{ template "harness-delegate-ng.fullname" . }}
   {{- end }}
+  {{- if .Values.destinationCaPath }}
+  DESTINATION_CA_PATH: {{ .Values.destinationCaPath }}
+  {{- end }}
 
 

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imagePullSecret }}
       {{- end }}
+      securityContext:
+        fsGroup: 1001
       containers:
         - name: delegate
           image: {{ .Values.delegateDockerImage }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -83,6 +83,11 @@ spec:
               mountPath: {{ .Values.shared_certificates.certs_path }}
               subPath:  ca.bundle
           {{- end }}
+          {{- if $.Values.delegateCustomCa.secretName }}
+            - name: custom-certs
+              mountPath: {{ .Values.delegateCustomCa.path }}
+              readOnly: true
+          {{- end }}
           {{- with .Values.custom_mounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -94,6 +99,12 @@ spec:
             items:
             - key: ca.bundle
               path: ca.bundle
+      {{- end }}
+      {{- if $.Values.delegateCustomCa.secretName }}
+        - name: custom-certs
+          secret:
+            secretName: {{ .Values.delegateCustomCa.secretName }}
+            defaultMode: 400
       {{- end }}
       {{- with .Values.custom_volumes }}
         {{- toYaml . | nindent 8 }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           {{- end }}
           {{- if $.Values.delegateCustomCa.secretName }}
             - name: custom-certs
-              mountPath: {{ .Values.delegateCustomCa.path }}
+              mountPath: /opt/harness-delegate/ca-bundle/
               readOnly: true
           {{- end }}
           {{- with .Values.custom_mounts }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -16,6 +16,8 @@ spec:
         spec:
           serviceAccountName: {{ template "harness-delegate-ng.fullname" . }}-{{ .Values.upgrader.cronJobServiceAccountName }}
           restartPolicy: Never
+          securityContext:
+            fsGroup: 1001
           containers:
             - image: {{ .Values.upgrader.upgraderDockerImage }}
               name: upgrader
@@ -26,7 +28,7 @@ spec:
               volumeMounts:
               {{- if $.Values.upgraderCustomCa.secretName }}
                 - name: custom-certs
-                  mountPath: {{ .Values.upgraderCustomCa.path }}
+                  mountPath: /ca-bundle
                   readOnly: true
               {{- end }}
                 - name: config-volume

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -24,9 +24,20 @@ spec:
                 - secretRef:
                     name: {{ include "harness-delegate-ng.upgraderDelegateToken" . }}
               volumeMounts:
+              {{- if $.Values.upgraderCustomCa.secretName }}
+                - name: custom-certs
+                  mountPath: {{ .Values.upgraderCustomCa.path }}
+                  readOnly: true
+              {{- end }}
                 - name: config-volume
                   mountPath: /etc/config
           volumes:
+          {{- if $.Values.upgraderCustomCa.secretName }}
+            - name: custom-certs
+              secret:
+                secretName: {{ .Values.upgraderCustomCa.secretName }}
+                defaultMode: 400
+          {{- end }}
             - name: config-volume
               configMap:
                 name: {{ .Values.delegateName }}-upgrader-config

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -113,7 +113,6 @@ securityContext:
 delegateSecurityContext:
   allowPrivilegeEscalation: false
   runAsUser: 0
-  fsGroup: 1001
 
 
 nextGen: true

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -138,8 +138,8 @@ existingDelegateToken: ""
 # Make sure that the destination path is not same as the default CA certificate path of the corresponding container image.
 #
 # If you want to override the default certificate file, make sure the Kubernetes secret or config map (from step one) includes all certificates required by the pipelines that will use this build infrastructure.
-
-# shared_certificates is deprecated please use delegateCustomCa to use custom certs in delegate
+# This is LEGACY way to adding cert, we recommend to use destinationCaPath, please follow the document:
+# https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/
 shared_certificates:
   # Location in the delegate to which the ca_bundle will be mounted or a location in the custom delegate image to which the
   # CA chain has already been placed as part of creating the custom delegate image
@@ -196,7 +196,11 @@ dnsConfig: {}
 dnsPolicy: ""
 
 upgraderCustomCa:
-  secretName: upgraderCert
+  secretName:
 
 delegateCustomCa:
-  secretName: delegateCert
+  secretName:
+
+# This is recommended way of using custom certs with CI.
+# Please refer: https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/
+destinationCaPath:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -147,13 +147,13 @@ shared_certificates:
   # ca_bundle should be the text of the CA Bundle to include in a secret
   #
   # Note: when defined, the secret will be mounted to the certs_path location on the delegate
-  ca_bundle:
-     -----BEGIN CERTIFICATE-----
-     XXXXXXXXXXXXXXXXXXXXXXXXXXX
-     -----END CERTIFICATE-------
-     -----BEGIN CERTIFICATE-----
-     XXXXXXXXXXXXXXXXXXXXXXXXXXX
-     -----END CERTIFICATE-------
+  ca_bundle: # |
+  #   -----BEGIN CERTIFICATE-----
+  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
+  #   -----END CERTIFICATE-------
+  #   -----BEGIN CERTIFICATE-----
+  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
+  #   -----END CERTIFICATE-------
 
   # CI Mount targets are the locations that the secrets should be mounted in the CI Images.  This will share any CA chain defined in the certs_path key to any CI image
   # configured in the pod.
@@ -161,9 +161,6 @@ shared_certificates:
     # - /etc/ssl/certs/ca-bundle.crt
     # - /etc/ssl/certs/ca-certificates.crt
     # - /kaniko/ssl/certs/additional-ca-cert-bundle.crt
-
-custom_certs:
-  secretName:
 
 custom_envs:
 

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -137,6 +137,8 @@ existingDelegateToken: ""
 # Make sure that the destination path is not same as the default CA certificate path of the corresponding container image.
 #
 # If you want to override the default certificate file, make sure the Kubernetes secret or config map (from step one) includes all certificates required by the pipelines that will use this build infrastructure.
+
+# shared_certificates is deprecated please use delegateCustomCa to use custom certs in delegate
 shared_certificates:
   # Location in the delegate to which the ca_bundle will be mounted or a location in the custom delegate image to which the
   # CA chain has already been placed as part of creating the custom delegate image
@@ -145,13 +147,13 @@ shared_certificates:
   # ca_bundle should be the text of the CA Bundle to include in a secret
   #
   # Note: when defined, the secret will be mounted to the certs_path location on the delegate
-  ca_bundle: # |
-  #   -----BEGIN CERTIFICATE-----
-  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
-  #   -----END CERTIFICATE-------
-  #   -----BEGIN CERTIFICATE-----
-  #   XXXXXXXXXXXXXXXXXXXXXXXXXXX
-  #   -----END CERTIFICATE-------
+  ca_bundle:
+     -----BEGIN CERTIFICATE-----
+     XXXXXXXXXXXXXXXXXXXXXXXXXXX
+     -----END CERTIFICATE-------
+     -----BEGIN CERTIFICATE-----
+     XXXXXXXXXXXXXXXXXXXXXXXXXXX
+     -----END CERTIFICATE-------
 
   # CI Mount targets are the locations that the secrets should be mounted in the CI Images.  This will share any CA chain defined in the certs_path key to any CI image
   # configured in the pod.
@@ -159,6 +161,9 @@ shared_certificates:
     # - /etc/ssl/certs/ca-bundle.crt
     # - /etc/ssl/certs/ca-certificates.crt
     # - /kaniko/ssl/certs/additional-ca-cert-bundle.crt
+
+custom_certs:
+  secretName:
 
 custom_envs:
 
@@ -191,3 +196,11 @@ dnsConfig: {}
 #    - name: edns0
 
 dnsPolicy: ""
+
+upgraderCustomCa:
+  path: /ca-bundle
+  secretName: upgraderCert
+
+delegateCustomCa:
+  path: /opt/harness-delegate/ca-bundle/
+  secretName: delegateCert

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -113,6 +113,8 @@ securityContext:
 delegateSecurityContext:
   allowPrivilegeEscalation: false
   runAsUser: 0
+  fsGroup: 1001
+
 
 nextGen: true
 
@@ -195,9 +197,7 @@ dnsConfig: {}
 dnsPolicy: ""
 
 upgraderCustomCa:
-  path: /ca-bundle
   secretName: upgraderCert
 
 delegateCustomCa:
-  path: /opt/harness-delegate/ca-bundle/
   secretName: delegateCert


### PR DESCRIPTION
Changes:
- User will be able to add custom cert at fix path in delegate at:  /opt/harness-delegate/ca-bundle/ This path is fixed because we can only add alternate path in custom image and in custom image volume isn't required because certs are baked in. For this approach to work user must add secretName which contains custom certs.

- User will be able to add custom cert at fix path in upgrader at:  /ca-bundle . For this approach to work user must add secretName which contains custom certs

- Add support for DESTINATION_CA_PATH to use custom cert in CI pods, CI_MOUNT_VOLUMES are also supported same as https://developer.harness.io/docs/continuous-integration/use-ci/set-up-build-infrastructure/k8s-build-infrastructure/configure-a-kubernetes-build-farm-to-use-self-signed-certificates/

Testing:
- Bought up delegate with certs.
- Bought up delegate without certs (it failed)
- Bought up upgrader with certs.
- Bought up upgrader without certs (it failed)

<img width="1728" alt="Screenshot 2023-12-11 at 6 57 10 PM" src="https://github.com/harness/delegate-helm-chart/assets/102655013/37a7cff0-2129-4a34-973e-3728e2f622ba">
