### PR TITLE
expose container port for api

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
+            - name: api
+              containerPort: 3460
           resources:
             limits:
               memory: {{ include "harness-delegate-ng.assignedMemory" .}}


### PR DESCRIPTION
I would like to add a named port to the delegate deployment for the api.

I am not sure what else this API is used for other than /health and /metrics, but I am using PodMonitor to define scrape targets, which requires a **named port** to collect metrics.

https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/PodMonitor/v1@v0.7.0

I do not belive this needs to be further templated as the port is defined in the liveprobes. `prometheus.io/port: "3460"` is in the values but I am not sure if we should drive this port from that, I belive this port is part of the delegate itself and wouldnt be changed by the user. 