### PR TITLE
fix: GitVersion

### DIFF
--- a/harness-delegate-ng/templates/hpa.yaml
+++ b/harness-delegate-ng/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.autoscaling.enabled) (semverCompare ">=1.23.x-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if and (.Values.autoscaling.enabled) (semverCompare ">=1.23.x-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:


### PR DESCRIPTION
closes #60 

```
➜  delegate-helm-chart git:(main) ✗ helm template --namespace harness-delegate-ng --create-namespace \
  ./harness-delegate-ng \
  --set delegateName=helm-delegate \
  --set accountId=wlgELJ0TTre5aZhzpt8gVA \
  --set delegateToken=xxxxxx \
  --set managerEndpoint=https://app.harness.io/gratis \
  --set delegateDockerImage=harness/delegate:24.01.82202 \
  --set replicas=1 --set upgrader.enabled=true --set autoscaling.enabled=true | grep 'autoscaling/v2' -A 24
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: helm-delegate
  namespace: harness-delegate-ng
  labels:
    helm.sh/chart: harness-delegate-ng-1.0.14
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: helm-delegate
    app.kubernetes.io/instance: release-name
    harness.io/name: helm-delegate
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: helm-delegate
  minReplicas: 1
  maxReplicas: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
```