### PR TITLE
Add HTTP_PROXY and HTTPS_PROXY env vars to proxyConfigMap

### DIFF
--- a/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
+++ b/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
@@ -10,6 +10,8 @@ data:
   PROXY_HOST: {{ .Values.proxyHost | quote }}
   PROXY_PORT: {{ .Values.proxyPort | quote }}
   PROXY_SCHEME: {{ .Values.proxyScheme | quote }}
+  HTTP_PROXY: "{{ .Values.proxyScheme | trim }}://{{ .Values.proxyHost | trim }}:{{ .Values.proxyPort | trim }}"
+  HTTPS_PROXY: "{{ .Values.proxyScheme | trim }}://{{ .Values.proxyHost | trim }}:{{ .Values.proxyPort | trim }}"
   {{- if .Values.noProxy }}
   NO_PROXY: {{ .Values.noProxy | quote }}
   {{- end }}


### PR DESCRIPTION
We are using a proxy for outbound traffic, the existing env variables works with the delegate but tools such as helm will need these to work properly.