### PR TITLE
allowing specific image repo and setting cpu limits

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: delegate
-          image: {{ .Values.delegateDockerImage }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           {{- if .Values.securityContext.runAsRoot }}
           securityContext:
             {{- toYaml .Values.delegateSecurityContext | nindent 12 }}
@@ -45,9 +45,12 @@ spec:
               containerPort: 3460
           resources:
             limits:
+              {{- if .Values.cpuLimit }}
+              cpu: {{ .Values.cpuLimit }}
+              {{- end }}
               memory: {{ include "harness-delegate-ng.assignedMemory" .}}
             requests:
-              cpu: {{ .Values.cpu }}
+              cpu: {{ .Values.cpuRequest }}
               memory: {{ include "harness-delegate-ng.assignedMemory" .}}
           startupProbe:
             httpGet:

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -19,9 +19,9 @@ spec:
           securityContext:
             fsGroup: 1001
           containers:
-            - image: {{ .Values.upgrader.upgraderDockerImage }}
+            - image: {{ .Values.upgrader.image.repository }}:{{ .Values.upgrader.image.tag }}
               name: upgrader
-              imagePullPolicy: Always
+              imagePullPolicy: {{ .Values.upgrader.image.pullPolicy }}
               envFrom:
                 - secretRef:
                     name: {{ include "harness-delegate-ng.upgraderDelegateToken" . }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -4,6 +4,8 @@
 
 image:
   pullPolicy: Always
+  repository: harness/delegate
+  tag: 24.01.82108
 
 fullnameOverride: ""
 
@@ -17,7 +19,7 @@ serviceAccount:
   name: ""
 
 service:
- # type: ClusterIP
+  # type: ClusterIP
   port: 8080
 
 # Edit this if you want to enable horizontal pod autoscaling
@@ -41,7 +43,6 @@ delegateName: harness-delegate-ng
 deployMode: "KUBERNETES"
 
 delegateDockerImage: harness/delegate:24.01.82108
-
 
 # Annotations for delegate deployment, prometheus is added by default
 annotations:
@@ -88,7 +89,8 @@ replicas: 1
 deploymentStrategy: "RollingUpdate"
 
 # Resource limits of container running delegate image in kubernetes
-cpu: 1
+cpuRequest: 1
+cpuLimit: ""
 memory: 2048
 
 # Script to run before delegate installation
@@ -101,7 +103,10 @@ javaOpts: "-Xms64M"
 
 upgrader:
   enabled: true
-  upgraderDockerImage: "harness/upgrader:latest"
+  image:
+    pullPolicy: Always
+    repository: harness/upgrader
+    tag: latest
   cronJobServiceAccountName: "upgrader-cronjob-sa"
   # Use existing Secret which stores UPGRADER_TOKEN key instead of creating a new one. The value should be set with the `UPGRADER_TOKEN` key inside the secret.
   ## The use of external secrets allows you to manage credentials from external tools like Vault, 1Password, SealedSecrets, among other.
@@ -121,7 +126,6 @@ securityContext:
 delegateSecurityContext:
   allowPrivilegeEscalation: false
   runAsUser: 0
-
 
 nextGen: true
 


### PR DESCRIPTION
Our clusters requires the CPU limit to be present or else a default of 250m is set, so we need to ensure the chart allows for it. 
Also, when using charts, the best practice is to use the default PIN version within the chart while allowing the repository to be changed (cached/passthrough registries)