### PR TITLE
feat: set security context for upgrader

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
   namespace: {{ .Release.Namespace }}
 spec:
-  schedule: "0 */1 * * *"
+  schedule: "* */1 * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 20
   jobTemplate:
@@ -28,6 +28,7 @@ spec:
               image: {{ .Values.upgrader.upgraderDockerImage }}
               {{- end }}
               imagePullPolicy: {{ .Values.upgrader.image.pullPolicy }}
+              {{- if .Values.upgrader.securityContext }}
               securityContext:
                 {{- toYaml .Values.upgrader.securityContext | nindent 16 }}
               {{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -28,6 +28,9 @@ spec:
               image: {{ .Values.upgrader.upgraderDockerImage }}
               {{- end }}
               imagePullPolicy: {{ .Values.upgrader.image.pullPolicy }}
+              securityContext:
+                {{- toYaml .Values.upgrader.securityContext | nindent 16 }}
+              {{- end }}
               envFrom:
                 - secretRef:
                     name: {{ include "harness-delegate-ng.upgraderDelegateToken" . }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
   namespace: {{ .Release.Namespace }}
 spec:
-  schedule: "* */1 * * *"
+  schedule: "0 */1 * * *"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 20
   jobTemplate:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -129,6 +129,9 @@ upgrader:
   ## - Do not use Secrets managed by other helm delpoyments.
   existingUpgraderToken: ""
 
+  # Set security context for upgrader
+  securityContext:
+
 # This field is DEPRECATED, DON'T OVERRIDE/USE THIS!!
 # To set root/non-root access and other security context use delegateSecurityContext field below.
 # Not removing this field to maintain backward compatibility.


### PR DESCRIPTION
A customer has strict cluster security policies, one of which requires a specific security context on all containers.

We need to expose the security context for them so they can pass their security checks.