### PR TITLE
feat: add new permission type: ci user

### DIFF
--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -68,6 +68,8 @@ Fetch access level using kubernetes permission value
     {{- print "view" }}
   {{- else if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
     {{- print "namespace-admin" }}
+  {{- else if eq .Values.k8sPermissionsType "CI_USER" }}
+    {{- print "ci-user" }}
   {{- end }}
 {{- end }}
 
@@ -76,7 +78,7 @@ Fetch access level using kubernetes permission value
 Check if custom role is provided in k8sPermissionsType
 */}}
 {{- define "harness-delegate-ng.useCustomRole" -}}
-  {{- if or (or (eq .Values.k8sPermissionsType "CLUSTER_ADMIN") (eq .Values.k8sPermissionsType "CLUSTER_VIEWER") ) (eq .Values.k8sPermissionsType "NAMESPACE_ADMIN") }}
+  {{- if or (or (or (eq .Values.k8sPermissionsType "CLUSTER_ADMIN") (eq .Values.k8sPermissionsType "CLUSTER_VIEWER") ) (eq .Values.k8sPermissionsType "NAMESPACE_ADMIN") ) (eq .Values.k8sPermissionsType "CI_USER") }}
   {{- print "false" }}
   {{- else }}
   {{- print "true" }}

--- a/harness-delegate-ng/templates/role.yaml
+++ b/harness-delegate-ng/templates/role.yaml
@@ -11,3 +11,20 @@ rules:
     resources: ["*"]
     verbs: ["*"]
 {{- end }}
+
+{{- if eq .Values.k8sPermissionsType "CI_USER" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-harness-ci-user
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch"]
+{{- end }}

--- a/harness-delegate-ng/templates/roleBinding.yaml
+++ b/harness-delegate-ng/templates/roleBinding.yaml
@@ -16,3 +16,21 @@ roleRef:
   name: {{ template "harness-delegate-ng.fullname" . }}-harness-namespace-admin
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+
+{{- if eq .Values.k8sPermissionsType "CI_USER" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "harness-delegate-ng.fullname" . }}-harness-ci-user
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "harness-delegate-ng.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ template "harness-delegate-ng.fullname" . }}-harness-ci-user
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -77,7 +77,7 @@ livenessProbe:
 description: ""
 tags: ""
 
-# Permissions for installed delegate, could be CLUSTER_ADMIN, CLUSTER_VIEWER or NAMESPACE_ADMIN
+# Permissions for installed delegate, could be CLUSTER_ADMIN, CLUSTER_VIEWER, NAMESPACE_ADMIN or CI_USER
 # For using custom role: Create role in kubernetes cluster and refer role in k8sPermissionsType field.
 # for example if your custom role name is custom-role, then you need to add
 #k8sPermissionsType: "custom-role"


### PR DESCRIPTION
add a new permission type: `CI_USER`.

this provisions a namespace role and binding for a custom role that gives just enough permissions to run CI (or IaC) builds in the namespace that the delegate is deployed to.

https://developer.harness.io/docs/platform/connectors/cloud-providers/ref-cloud-providers/kubernetes-cluster-connector-settings-reference/#builds-ci