### PR TITLE
Ignore replicas when HPA is enabled

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ include "harness-delegate-ng.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
     matchLabels:


### PR DESCRIPTION
Otherwise CI tools will always detect a change if replicas != current replicas of the hpa.

And also it will force that number on apply, even if the service is scaled.