### PR TITLE
add support for custom_init_containers & custom_containers in delegate deployment template

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: 1001
+      {{- if .Values.custom_init_containers }}
+      initContainers: 
+        {{- toYaml .Values.custom_init_containers | nindent 8 }}
+      {{- end }}
       containers:
         - name: delegate
           {{- if and .Values.image.registry .Values.image.repository}}
@@ -111,6 +115,9 @@ spec:
           {{- with .Values.custom_mounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.custom_containers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
       {{- if $.Values.shared_certificates.ca_bundle }}
         - name: certvol

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -115,9 +115,9 @@ spec:
           {{- with .Values.custom_mounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- with .Values.custom_containers }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- with .Values.custom_containers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if $.Values.shared_certificates.ca_bundle }}
         - name: certvol

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -191,6 +191,18 @@ shared_certificates:
     # - /etc/ssl/certs/ca-certificates.crt
     # - /kaniko/ssl/certs/additional-ca-cert-bundle.crt
 
+# additional init containers for the delegate pod
+custom_init_containers:
+  # - name: init-container
+  #   image: busybox
+  #   command: ['sh', '-c', 'echo "Hello from init container!"']
+
+# additional sidecar containers for the delegate pod
+custom_containers:
+  # - name: sidecar
+  #   image: busybox
+  #   command: ['sh', '-c', 'echo "Hello from sidecar!"']
+
 # additional environment variables for the delegate pod
 custom_envs:
   # - name: DELEGATE_TASK_CAPACITY


### PR DESCRIPTION
adds support for injecting init containers and sidecar containers into the deployment spec of the delegate.