### PR TITLE
feat: [PL-57609]: Support to add labels and annotations in deployment and pod spec

### DIFF
--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -126,3 +126,18 @@ Define the upgrader token name
 {{- .Values.upgrader.existingUpgraderToken | trunc 63 | toString }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "harness-delegate-ng.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- if .value }}
+            {{- tpl (.value | toYaml) .context }}
+        {{- end }}
+    {{- end }}
+{{- end -}}

--- a/harness-delegate-ng/templates/ccm/cost-access.yaml
+++ b/harness-delegate-ng/templates/ccm/cost-access.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibility
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""
@@ -65,6 +72,13 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-ccm-visibility-roleBinding
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/harness-delegate-ng/templates/cluster-rolebinding.yaml
+++ b/harness-delegate-ng/templates/cluster-rolebinding.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-{{ .Values.k8sPermissionsType | lower | replace "_" "-" }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "harness-delegate-ng.serviceAccountName" . }}

--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   ACCOUNT_ID: {{ .Values.accountId }}
   MANAGER_HOST_AND_PORT : {{ .Values.managerEndpoint }}

--- a/harness-delegate-ng/templates/customRoleBinding.yaml
+++ b/harness-delegate-ng/templates/customRoleBinding.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "harness-delegate-ng.serviceAccountName" . }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -3,12 +3,20 @@ kind: Deployment
 metadata:
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- if .Values.delegateLabels }}
       {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.delegateAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.delegateAnnotations }}
   annotations:
-    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateAnnotations "context" $ ) | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.delegateAnnotations }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
   name: {{ include "harness-delegate-ng.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -28,11 +36,17 @@ spec:
         {{- toYaml .Values.annotations | nindent 8 }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
         checksum/configmap: {{ include (print .Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
+        {{- if .Values.commonAnnotations }}
+          {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
         {{- if .Values.delegateAnnotations }}
           {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
       labels:
         {{- include "harness-delegate-ng.selectorLabels" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+          {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
         {{- if .Values.delegateLabels }}
           {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateLabels "context" $ ) | nindent 8 }}
         {{- end }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -3,6 +3,13 @@ kind: Deployment
 metadata:
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.delegateLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.delegateAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   name: {{ include "harness-delegate-ng.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,8 +28,17 @@ spec:
         {{- toYaml .Values.annotations | nindent 8 }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | trunc 63 }}
         checksum/configmap: {{ include (print .Template.BasePath "/configMap.yaml") . | sha256sum | trunc 63 }}
+        {{- if .Values.delegateAnnotations }}
+          {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "harness-delegate-ng.selectorLabels" . | nindent 8 }}
+        {{- if .Values.delegateLabels }}
+          {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegateLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.delegatePodLabels }}
+          {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.delegatePodLabels "context" $ ) | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "harness-delegate-ng.serviceAccountName" . }}
       terminationGracePeriodSeconds: 600
@@ -34,7 +50,7 @@ spec:
       securityContext:
         fsGroup: 1001
       {{- if .Values.custom_init_containers }}
-      initContainers: 
+      initContainers:
         {{- toYaml .Values.custom_init_containers | nindent 8 }}
       {{- end }}
       containers:

--- a/harness-delegate-ng/templates/hpa.yaml
+++ b/harness-delegate-ng/templates/hpa.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/harness-delegate-ng/templates/hpaLegacy.yaml
+++ b/harness-delegate-ng/templates/hpaLegacy.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
+++ b/harness-delegate-ng/templates/proxy/proxyConfigMap.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   PROXY_HOST: {{ .Values.proxyHost | quote }}
   PROXY_PORT: {{ .Values.proxyPort | quote }}

--- a/harness-delegate-ng/templates/proxy/proxySecret.yaml
+++ b/harness-delegate-ng/templates/proxy/proxySecret.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   # Enter base64 encoded username and password if using proxy

--- a/harness-delegate-ng/templates/role.yaml
+++ b/harness-delegate-ng/templates/role.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]

--- a/harness-delegate-ng/templates/roleBinding.yaml
+++ b/harness-delegate-ng/templates/roleBinding.yaml
@@ -7,6 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "harness-delegate-ng.serviceAccountName" . }}

--- a/harness-delegate-ng/templates/secret.yaml
+++ b/harness-delegate-ng/templates/secret.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   # Base 64 encoded account secret

--- a/harness-delegate-ng/templates/serviceaccount.yaml
+++ b/harness-delegate-ng/templates/serviceaccount.yaml
@@ -6,8 +6,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateConfigMap.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{- with .Values.shared_certificates }}
   ADDITIONAL_CERTS_PATH: {{ .certs_path }}

--- a/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
+++ b/harness-delegate-ng/templates/shared_certificates/certificateSecret.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   ca.bundle: {{ .Values.shared_certificates.ca_bundle | b64enc | quote }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   config.yaml: |
     mode: Delegate

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -4,6 +4,13 @@ kind: CronJob
 metadata:
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
   namespace: {{ .Release.Namespace }}
 spec:

--- a/harness-delegate-ng/templates/upgrader/upgraderRole.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderRole.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: ["batch", "apps", "extensions"]
     resources: ["cronjobs"]

--- a/harness-delegate-ng/templates/upgrader/upgraderRoleBinding.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderRoleBinding.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "harness-delegate-ng.fullname" . }}-{{ .Values.upgrader.cronJobServiceAccountName }}

--- a/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderSecret.yaml
@@ -7,6 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   UPGRADER_TOKEN: {{ .Values.delegateToken | b64enc | quote }}

--- a/harness-delegate-ng/templates/upgrader/upgraderServiceAccount.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderServiceAccount.yaml
@@ -6,4 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+      {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -46,20 +46,18 @@ deployMode: "KUBERNETES"
 
 delegateDockerImage: harness/delegate:24.07.83404
 
+commonAnnotations: {}  # Annotations that will be applied to all resources
+delegateAnnotations: {}  # Annotations that will be applied to both pod and deployment spec for Delegate
 # Annotations for delegate deployment, prometheus is added by default
 annotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "3460"
   prometheus.io/path: "/api/metrics"
 
-# Annotations that will be applied to both pod and deployment spec
-delegateAnnotations: {}
 
-# Labels that will be applied to pod spec
-delegatePodLabels: {}
-
-# Labels that will be applied to both deployment and pod spec
-delegateLabels: {}
+commonLabels: {}  # Labels that will be applied to all resources
+delegatePodLabels: {}  # Labels that will be applied to pod spec
+delegateLabels: {}  # Labels that will be applied to both deployment and pod spec for Delegate
 
 imagePullSecret: ""
 

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -52,6 +52,15 @@ annotations:
   prometheus.io/port: "3460"
   prometheus.io/path: "/api/metrics"
 
+# Annotations that will be applied to both pod and deployment spec
+delegateAnnotations: {}
+
+# Labels that will be applied to pod spec
+delegatePodLabels: {}
+
+# Labels that will be applied to both deployment and pod spec
+delegateLabels: {}
+
 imagePullSecret: ""
 
 # Endpoint that will point to harness platform. For accessing SAAS platform use the default value.


### PR DESCRIPTION
## Changes
This PR adds support to add additional labels and annotations to all resources at three different levels.
```
 # These will add annotations and labels to all resources
commonAnnotations: {}
commonLabels: {}

# These will add annotations and labels to both delegate deployment and pod spec
delegateLabels: {}
delegateAnnotations: {}

# These will add annotations and labels to Pod Spec
annotations: {}.  # Already present
delegatePodLabels: {}
```

## Testing
I have tested these scenarios for all resources

1. should work with common annotations
2. should work with common labels
3. should work with common annotations and labels
4. should template without override

And these scenarios for deployment

1. should work with delegate annotations
2. should work with pod annotations
3. should work with common and delegate annotations
4. should work with common and pod annotations
5. should work with delegate and pod annotations
6. should work with common, delegate and pod annotations
7. should work with delegate labels
8. should work with pod labels
9. should work with common and delegate labels
10. should work with common and pod labels
11. should work with delegate and pod labels
12. should work with common, delegate and pod labels
13. should work with delegate annotations and labels
14. should work with pod annotations and labels
15. should work with delegate annotations and pod labels
16. should work with pod annotations and delegate labels

All the test cases passed in helm-unit test, screenshot attached
![Screenshot 2024-10-29 at 6 19 11 PM](https://github.com/user-attachments/assets/31b8ca19-b8d8-409d-8244-9796649e5660)

