### PR TITLE
feat: [PL-58735]: Add registry mirror helm option for upgrader

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -23,4 +23,7 @@ data:
     delegateConfig:
       accountId: {{ .Values.accountId }}
       managerHost: {{ .Values.managerEndpoint }}
+      {{- if .Values.upgrader.registryMirror }}
+      registryMirror: {{ .Values.upgrader.registryMirror }}
+      {{- end }}
 {{- end }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -120,6 +120,7 @@ javaOpts: "-Xms64M"
 upgrader:
   enabled: true
   upgraderDockerImage: "harness/upgrader:latest"
+  registryMirror: ""
   image:
     pullPolicy: Always
     # Uncomment below lines to use a custom registry + repository, a different repository or a different tag, this will override the upgraderDockerImage


### PR DESCRIPTION
Add option to specify upgrader registry mirror during helm installation. 

Generated Helm templates locally and made sure expected config is generated:

```
helm template ./harness-delegate-ng # No mirror configured
helm template ./harness-delegate-ng --set upgrader.registryMirror="https://us.gcr.io/harness/delegate/"
helm template ./harness-delegate-ng --set upgrader.registryMirror="us.gcr.io/harness"
```