### PR TITLE
fix: [PL-59074]: adds mTLS config in deployment, upgraderConfigMap and upgraderJob

### DIFF
--- a/harness-delegate-ng/templates/configMap.yaml
+++ b/harness-delegate-ng/templates/configMap.yaml
@@ -33,3 +33,7 @@ data:
   {{- if .Values.destinationCaPath }}
   DESTINATION_CA_PATH: {{ .Values.destinationCaPath }}
   {{- end }}
+  {{- if .Values.mTLS.secretName }}
+  DELEGATE_CLIENT_CERTIFICATE_PATH: "/etc/mtls/client.crt"
+  DELEGATE_CLIENT_CERTIFICATE_KEY_PATH: "/etc/mtls/client.key"
+  {{- end }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -127,14 +127,8 @@ spec:
             - configMapRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}-shared-certificates
                 optional: true
-          env:
-          {{- if .Values.mTLS.secretName }}
-            - name: DELEGATE_CLIENT_CERTIFICATE_PATH
-              value: "/etc/mtls/client.crt"
-            - name: DELEGATE_CLIENT_CERTIFICATE_KEY_PATH
-              value: "/etc/mtls/client.key"
-          {{- end }}
           {{- with .Values.custom_envs }}
+          env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -127,8 +127,14 @@ spec:
             - configMapRef:
                 name: {{ template "harness-delegate-ng.fullname" . }}-shared-certificates
                 optional: true
-          {{- with .Values.custom_envs }}
           env:
+          {{- if .Values.mTLS.secretName }}
+            - name: DELEGATE_CLIENT_CERTIFICATE_PATH
+              value: "/etc/mtls/client.crt"
+            - name: DELEGATE_CLIENT_CERTIFICATE_KEY_PATH
+              value: "/etc/mtls/client.key"
+          {{- end }}
+          {{- with .Values.custom_envs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -141,6 +147,10 @@ spec:
             - name: custom-certs
               mountPath: /opt/harness-delegate/ca-bundle/
               readOnly: true
+          {{- end }}
+          {{- if .Values.mTLS.secretName }}
+            - name: client-certificate
+              mountPath: /etc/mtls
           {{- end }}
           {{- with .Values.custom_mounts }}
             {{- toYaml . | nindent 12 }}
@@ -161,6 +171,12 @@ spec:
         - name: custom-certs
           secret:
             secretName: {{ .Values.delegateCustomCa.secretName }}
+            defaultMode: 400
+      {{- end }}
+      {{- if .Values.mTLS.secretName }}
+        - name: client-certificate
+          secret:
+            secretName: {{ .Values.mTLS.secretName }}
             defaultMode: 400
       {{- end }}
       {{- with .Values.custom_volumes }}

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -151,6 +151,7 @@ spec:
           {{- if .Values.mTLS.secretName }}
             - name: client-certificate
               mountPath: /etc/mtls
+              readOnly: true
           {{- end }}
           {{- with .Values.custom_mounts }}
             {{- toYaml . | nindent 12 }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -26,4 +26,17 @@ data:
       {{- if .Values.upgrader.registryMirror }}
       registryMirror: {{ .Values.upgrader.registryMirror }}
       {{- end }}
+      {{- if .Values.mTLS.secretName }}
+        {{- if .Values.mTLS.clientCertificateFilePath }}
+      clientCertificateFilePath: {{ .Values.mTLS.clientCertificateFilePath }}
+        {{- else }}
+      clientCertificateFilePath: "/etc/mtls/client.crt"
+        {{- end }}
+
+        {{- if .Values.mTLS.clientCertificateKeyFilePath }}
+      clientCertificateKeyFilePath: {{ .Values.mTLS.clientCertificateKeyFilePath }}
+        {{- else }}
+      clientCertificateKeyFilePath: "/etc/mtls/client.key"
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -27,14 +27,14 @@ data:
       registryMirror: {{ .Values.upgrader.registryMirror }}
       {{- end }}
       {{- if .Values.mTLS.secretName }}
-        {{- if .Values.mTLS.clientCertificateFilePath }}
-      clientCertificateFilePath: {{ .Values.mTLS.clientCertificateFilePath }}
+        {{- if .Values.mTLS.clientCertificateFileName }}
+      clientCertificateFilePath: "/etc/mtls/{{ .Values.mTLS.clientCertificateFileName }}"
         {{- else }}
       clientCertificateFilePath: "/etc/mtls/client.crt"
         {{- end }}
 
-        {{- if .Values.mTLS.clientCertificateKeyFilePath }}
-      clientCertificateKeyFilePath: {{ .Values.mTLS.clientCertificateKeyFilePath }}
+        {{- if .Values.mTLS.clientCertificateKeyFileName }}
+      clientCertificateKeyFilePath: "/etc/mtls/{{ .Values.mTLS.clientCertificateKeyFileName }}"
         {{- else }}
       clientCertificateKeyFilePath: "/etc/mtls/client.key"
         {{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -27,16 +27,7 @@ data:
       registryMirror: {{ .Values.upgrader.registryMirror }}
       {{- end }}
       {{- if .Values.mTLS.secretName }}
-        {{- if .Values.mTLS.clientCertificateFileName }}
-      clientCertificateFilePath: "/etc/mtls/{{ .Values.mTLS.clientCertificateFileName }}"
-        {{- else }}
       clientCertificateFilePath: "/etc/mtls/client.crt"
-        {{- end }}
-
-        {{- if .Values.mTLS.clientCertificateKeyFileName }}
-      clientCertificateKeyFilePath: "/etc/mtls/{{ .Values.mTLS.clientCertificateKeyFileName }}"
-        {{- else }}
       clientCertificateKeyFilePath: "/etc/mtls/client.key"
-        {{- end }}
       {{- end }}
 {{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -51,6 +51,7 @@ spec:
               {{- if .Values.mTLS.secretName }}
                 - name: client-certificate
                   mountPath: /etc/mtls
+                  readOnly: true
               {{- end }}
                 - name: config-volume
                   mountPath: /etc/config

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -48,6 +48,10 @@ spec:
                   mountPath: /ca-bundle
                   readOnly: true
               {{- end }}
+              {{- if .Values.mTLS.secretName }}
+                - name: client-certificate
+                  mountPath: /etc/mtls
+              {{- end }}
                 - name: config-volume
                   mountPath: /etc/config
           volumes:
@@ -56,6 +60,11 @@ spec:
               secret:
                 secretName: {{ .Values.upgraderCustomCa.secretName }}
                 defaultMode: 400
+          {{- end }}
+          {{- if .Values.mTLS.secretName }}
+            - name: client-certificate
+              secret:
+                secretName: {{ .Values.mTLS.secretName }}
           {{- end }}
             - name: config-volume
               configMap:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -13,8 +13,6 @@ fullnameOverride: ""
 
 mTLS:
   secretName: ""
-  clientCertificateFileName: ""
-  clientCertificateKeyFileName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -11,6 +11,11 @@ image:
 
 fullnameOverride: ""
 
+mTLS:
+  secretName: ""
+  clientCertificateFilePath: ""
+  clientCertificateKeyFilePath: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -13,8 +13,8 @@ fullnameOverride: ""
 
 mTLS:
   secretName: ""
-  clientCertificateFilePath: ""
-  clientCertificateKeyFilePath: ""
+  clientCertificateFileName: ""
+  clientCertificateKeyFileName: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Currently, there is no configuration available to enable mTLS on the delegate when installed using the Helm command. To support mTLS, specific environment variables, volumes, and volume mounts must be included in the generated Helm template.

After this change, it is required to provide a secret name in the Helm install command. This secret should contain the TLS certificate and private key. Some changes are still needs to be done at the backend side for updating the manager URL.

FR: https://developer.harness.io/docs/platform/delegates/secure-delegates/delegate-mtls-support/