### PR TITLE
fix: [PL-59074]: Corrects mtls clientCertificatePaths indentation in upgraderConfigMap…

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -20,6 +20,8 @@ data:
     workloadName: {{ template "harness-delegate-ng.fullname" . }}
     namespace: {{ .Release.Namespace }}
     containerName: delegate
+    clientCertificateFilePath: "/etc/mtls/client.crt"
+    clientCertificateKeyFilePath: "/etc/mtls/client.key"
     delegateConfig:
       accountId: {{ .Values.accountId }}
       managerHost: {{ .Values.managerEndpoint }}
@@ -27,7 +29,5 @@ data:
       registryMirror: {{ .Values.upgrader.registryMirror }}
       {{- end }}
       {{- if .Values.mTLS.secretName }}
-      clientCertificateFilePath: "/etc/mtls/client.crt"
-      clientCertificateKeyFilePath: "/etc/mtls/client.key"
       {{- end }}
 {{- end }}


### PR DESCRIPTION
In this PR: https://github.com/harness/delegate-helm-chart/pull/101 we added:
clientCertificateFilePath: "/etc/mtls/client.crt"
clientCertificateKeyFilePath: "/etc/mtls/client.key"

But the indentation is incorrect there, it should be inside: data -> config.yaml