### PR TITLE
Adding support for custom cluster role

### DIFF
--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -71,18 +71,6 @@ Fetch access level using kubernetes permission value
   {{- end }}
 {{- end }}
 
-
-{{/*
-Check if custom role is provided in k8sPermissionsType
-*/}}
-{{- define "harness-delegate-ng.useCustomRole" -}}
-  {{- if or (or (eq .Values.k8sPermissionsType "CLUSTER_ADMIN") (eq .Values.k8sPermissionsType "CLUSTER_VIEWER") ) (eq .Values.k8sPermissionsType "NAMESPACE_ADMIN") }}
-  {{- print "false" }}
-  {{- else }}
-  {{- print "true" }}
-  {{- end }}
-{{- end }}
-
 {{/*
 Memory assigned to container in Mi
 */}}

--- a/harness-delegate-ng/templates/customClusterRoleBinding.yaml
+++ b/harness-delegate-ng/templates/customClusterRoleBinding.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.k8sPermissionsType (or (eq .Values.k8sPermissionsType "CLUSTER_ADMIN") (eq .Values.k8sPermissionsType "CLUSTER_VIEWER")) }}
+{{- if and (ne (.Values.CustomClusterRole | default "") "") (or (not .Values.k8sPermissionsType) (eq .Values.k8sPermissionsType "")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "harness-delegate-ng.fullname" . }}-{{ .Values.k8sPermissionsType | lower | replace "_" "-" }}
+  name: {{ template "harness-delegate-ng.fullname" . }}-custom-clusterRoleBinding
   labels:
     {{- include "harness-delegate-ng.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -18,6 +18,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "harness-delegate-ng.accessLevel" .}}
+  name: {{ .Values.CustomClusterRole }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/harness-delegate-ng/templates/customRoleBinding.yaml
+++ b/harness-delegate-ng/templates/customRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "harness-delegate-ng.useCustomRole" .) "true" }}
+{{- if and (ne (.Values.CustomRole | default "") "") (or (not .Values.k8sPermissionsType) (eq .Values.k8sPermissionsType "")) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -19,6 +19,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ .Values.k8sPermissionsType}}
+  name: {{ .Values.CustomRole }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/harness-delegate-ng/templates/role.yaml
+++ b/harness-delegate-ng/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
+{{- if and .Values.k8sPermissionsType (eq .Values.k8sPermissionsType "NAMESPACE_ADMIN") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/harness-delegate-ng/templates/roleBinding.yaml
+++ b/harness-delegate-ng/templates/roleBinding.yaml
@@ -1,5 +1,5 @@
 {{- $roleBindingName := print .Release.Namespace "-harness-namespace-admin" -}}
-{{- if eq .Values.k8sPermissionsType "NAMESPACE_ADMIN" }}
+{{- if and .Values.k8sPermissionsType (eq .Values.k8sPermissionsType "NAMESPACE_ADMIN") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -88,10 +88,13 @@ description: ""
 tags: ""
 
 # Permissions for installed delegate, could be CLUSTER_ADMIN, CLUSTER_VIEWER or NAMESPACE_ADMIN
-# For using custom role: Create role in kubernetes cluster and refer role in k8sPermissionsType field.
-# for example if your custom role name is custom-role, then you need to add
-#k8sPermissionsType: "custom-role"
 k8sPermissionsType: "CLUSTER_ADMIN"
+
+# Custom Role. Can't be used in conjunction with k8sPermissionsType.
+CustomRole: ""
+
+# Custom Cluster Role. Can't be used in conjunction with k8sPermissionsType.
+CustomClusterRole: ""
 
 # Number of pod replica running delegate image
 replicas: 1


### PR DESCRIPTION
Currently, you only allow custom roles, but we are using a custom cluster role in one of our delegates, and the binding for that one is not supported in this chart.

I'm adding a new template to create cluster role bindings, and at the same time introducing two variables to decide custom role or custom cluster role. This part is a breaking change, since k8sPermissionsType is not being used to decide the custom role name, since now there's more than one option. 