### PR TITLE
feat: enable imagePullSecret for upgrader job

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -23,6 +23,10 @@ spec:
         spec:
           serviceAccountName: {{ template "harness-delegate-ng.fullname" . }}-{{ .Values.upgrader.cronJobServiceAccountName }}
           restartPolicy: Never
+          {{- if .Values.upgrader.imagePullSecret }}
+          imagePullSecrets:
+          - name: {{ .Values.upgrader.imagePullSecret }}
+          {{- end }}
           securityContext:
             fsGroup: 1001
           containers:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -131,6 +131,8 @@ upgrader:
     # repository: null
     # tag: null
 
+  imagePullSecret: ""
+
   cronJobServiceAccountName: "upgrader-cronjob-sa"
   # Use existing Secret which stores UPGRADER_TOKEN key instead of creating a new one. The value should be set with the `UPGRADER_TOKEN` key inside the secret.
   ## The use of external secrets allows you to manage credentials from external tools like Vault, 1Password, SealedSecrets, among other.


### PR DESCRIPTION
This PR adds support for specifying an imagePullSecret in the Upgrader CronJob, enabling users to pull Docker images from private repositories.

- Added an optional imagePullSecret parameter in values.yaml.
- Updated the CronJob template to include the imagePullSecret when specified.

This change improves flexibility for users working with private container registries while maintaining backward compatibility.

