### PR TITLE
fix: b64dec error when enabling upgrader

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -35,6 +35,8 @@ data:
     proxyPort: {{ .Values.proxyPort }}
     {{- if .Values.proxyUser }}
     proxyUser: {{ .Values.proxyUser | b64dec}}
+    {{- end }}
+    {{- if .Values.proxyPassword }}
     proxyPassword: {{ .Values.proxyPassword | b64dec }}
     {{- end }}
 {{- end }}

--- a/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml
@@ -33,6 +33,8 @@ data:
     proxyScheme: {{ .Values.proxyScheme }}
     proxyHost: {{ .Values.proxyHost }}
     proxyPort: {{ .Values.proxyPort }}
+    {{- if .Values.proxyUser }}
     proxyUser: {{ .Values.proxyUser | b64dec}}
     proxyPassword: {{ .Values.proxyPassword | b64dec }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Recent helm release is failing because we call the b64dec function even when no value is passed, resulting in a failure.

```╭─riley@t480-0 ~/isengard  ‹master*›
╰─➤  helm repo update harness-delegate
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "harness-delegate" chart repository
Update Complete. ⎈Happy Helming!⎈
╭─riley@t480-0 ~/isengard  ‹master*›
╰─➤  helm upgrade -i helm-delegate --namespace harness-delegate-ng --create-namespace \
  harness-delegate/harness-delegate-ng \
  --set delegateName=helm-delegate \
  --set accountId=wlgELJ0TTre5aZhzpt8gVA \
  --set delegateToken=xxxxxxxxx \
  --set managerEndpoint=https://app.harness.io/gratis \
  --set delegateDockerImage=us-docker.pkg.dev/gar-prod-setup/harness-public/harness/delegate:25.07.86300 \
  --set replicas=1 --set upgrader.enabled=true
Release "helm-delegate" does not exist. Installing it now.
Error: template: harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml:36:38: executing "harness-delegate-ng/templates/upgrader/upgraderConfigMap.yaml" at <b64dec>: invalid value; expected string
```

This should only set those values when a user is set