### PR TITLE
feat: Added support for customizing rollingUpdate strategy

### DIFF
--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -31,9 +31,17 @@ spec:
   strategy:
     type: {{ .Values.deploymentStrategy | default "RollingUpdate" }}
     {{- if eq (.Values.deploymentStrategy | default "RollingUpdate") "RollingUpdate" }}
+    {{- with .Values.rollingUpdate }}
+    {{- if or .maxSurge .maxUnavailable }}
     rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdate.maxSurge | default 1 }}
-      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable | default 1 }}
+      {{- if .maxSurge }}
+      maxSurge: {{ .maxSurge | quote }}
+      {{- end }}
+      {{- if .maxUnavailable }}
+      maxUnavailable: {{ .maxUnavailable | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
     {{- end }}
   template:
     metadata:

--- a/harness-delegate-ng/templates/deployment.yaml
+++ b/harness-delegate-ng/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
       {{- include "harness-delegate-ng.selectorLabels" . | nindent 6 }}
   strategy:
     type: {{ .Values.deploymentStrategy | default "RollingUpdate" }}
+    {{- if eq (.Values.deploymentStrategy | default "RollingUpdate") "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdate.maxSurge | default 1 }}
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable | default 1 }}
+    {{- end }}
   template:
     metadata:
       annotations:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -100,6 +100,14 @@ replicas: 1
 # possible due to custom volumes or mounts that can only be attached to a single pod.
 deploymentStrategy: "RollingUpdate"
 
+# Rolling update configuration (only applies when deploymentStrategy is "RollingUpdate")
+# These settings control how many pods can be created/destroyed during updates
+rollingUpdate:
+  # Maximum number of pods that can be created above the desired replica count during updates
+  maxSurge: 1
+  # Maximum number of pods that can be unavailable during the update process
+  maxUnavailable: 1
+
 # Resource limits of container running delegate image in kubernetes
 # If you want to set custom resource limits, uncomment the below line and set the values for cpu and memory request/limit
 # resources:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -100,13 +100,14 @@ replicas: 1
 # possible due to custom volumes or mounts that can only be attached to a single pod.
 deploymentStrategy: "RollingUpdate"
 
-# Rolling update configuration (only applies when deploymentStrategy is "RollingUpdate")
-# These settings control how many pods can be created/destroyed during updates
-rollingUpdate:
-  # Maximum number of pods that can be created above the desired replica count during updates
-  maxSurge: 1
-  # Maximum number of pods that can be unavailable during the update process
-  maxUnavailable: 1
+# Rolling update configuration (only applies when deploymentStrategy is "RollingUpdate").
+# By default, these are not set so Kubernetes uses its own defaults (currently 25%).
+# Uncomment and set if you want to override the defaults. You may use integers or percentage strings (e.g., "25%")
+# rollingUpdate:
+#   # Maximum number of pods that can be created above the desired replica count during updates
+#   maxSurge: "25%"
+#   # Maximum number of pods that can be unavailable during the update process
+#   maxUnavailable: "25%"
 
 # Resource limits of container running delegate image in kubernetes
 # If you want to set custom resource limits, uncomment the below line and set the values for cpu and memory request/limit


### PR DESCRIPTION
This Solves the GitHub Issue #117 

✅ Addresses the core problem: Users can now customize maxSurge and maxUnavailable parameters to prevent rollout failures with HPA and low replica counts
✅ Backward compatible: Existing deployments will continue working with the same behavior (defaults to 1/1)
✅ Flexible configuration: Users can now set custom values in their values.yaml:
yaml
✅ Safe implementation: Only applies to RollingUpdate strategy, preventing errors with Recreate strategy


**How to test**
```
helm template test-release ./harness-delegate-ng --set accountId=test123 --set delegateToken=testtoken123 --set "rollingUpdate.maxSurge=2,rollingUpdate.maxUnavailable=25%" | grep -A 10 "strategy:"
```

**Expected Output**
```
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 2
      maxUnavailable: 25%
  template:
    metadata:
      annotations:
        prometheus.io/path: /api/metrics
        prometheus.io/port: "3460"
        prometheus.io/scrape: "true"