### PR TITLE
feat: [PL-63080]: Add schedule option to upgrader helm options

### DIFF
--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -14,7 +14,7 @@ metadata:
   name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
   namespace: {{ .Release.Namespace }}
 spec:
-  schedule: "0 */1 * * *"
+  schedule: {{ .Values.upgrader.schedule | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 20
   jobTemplate:

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -47,7 +47,7 @@ delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
 
-delegateDockerImage: harness/delegate:25.08.86503
+delegateDockerImage: harness/delegate:25.07.86300
 
 commonAnnotations: {}  # Annotations that will be applied to all resources
 delegateAnnotations: {}  # Annotations that will be applied to both pod and deployment spec for Delegate
@@ -100,15 +100,6 @@ replicas: 1
 # possible due to custom volumes or mounts that can only be attached to a single pod.
 deploymentStrategy: "RollingUpdate"
 
-# Rolling update configuration (only applies when deploymentStrategy is "RollingUpdate").
-# By default, these are not set so Kubernetes uses its own defaults (currently 25%).
-# Uncomment and set if you want to override the defaults. You may use integers or percentage strings (e.g., "25%")
-# rollingUpdate:
-#   # Maximum number of pods that can be created above the desired replica count during updates
-#   maxSurge: "25%"
-#   # Maximum number of pods that can be unavailable during the update process
-#   maxUnavailable: "25%"
-
 # Resource limits of container running delegate image in kubernetes
 # If you want to set custom resource limits, uncomment the below line and set the values for cpu and memory request/limit
 # resources:
@@ -139,6 +130,9 @@ upgrader:
     # registry: null
     # repository: null
     # tag: null
+  
+  # Schedule for the upgrader cronjob (cron format)
+  schedule: "0 */1 * * *"
 
   imagePullSecret: ""
 

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -47,7 +47,7 @@ delegateName: harness-delegate-ng
 
 deployMode: "KUBERNETES"
 
-delegateDockerImage: harness/delegate:25.07.86300
+delegateDockerImage: harness/delegate:25.08.86503
 
 commonAnnotations: {}  # Annotations that will be applied to all resources
 delegateAnnotations: {}  # Annotations that will be applied to both pod and deployment spec for Delegate
@@ -99,6 +99,15 @@ replicas: 1
 # The deployment strategy. Can be "RollingUpdate" or "Recreate". Can be usefull if a rolling update is not
 # possible due to custom volumes or mounts that can only be attached to a single pod.
 deploymentStrategy: "RollingUpdate"
+
+# Rolling update configuration (only applies when deploymentStrategy is "RollingUpdate").
+# By default, these are not set so Kubernetes uses its own defaults (currently 25%).
+# Uncomment and set if you want to override the defaults. You may use integers or percentage strings (e.g., "25%")
+# rollingUpdate:
+#   # Maximum number of pods that can be created above the desired replica count during updates
+#   maxSurge: "25%"
+#   # Maximum number of pods that can be unavailable during the update process
+#   maxUnavailable: "25%"
 
 # Resource limits of container running delegate image in kubernetes
 # If you want to set custom resource limits, uncomment the below line and set the values for cpu and memory request/limit


### PR DESCRIPTION
## PR Summary
Added upgrader schedule as a configurable parameter with default value "0 */1 * * *"

## Testing Process
 - Installed a delegate successfully with and without `upgrader.schedule` configuration 
 - Install command with `upgrader.schedule` configuration 
 ```
helm upgrade -i soumik-helm-delegate --namespace harness-delegate-ng --create-namespace . \
  --set delegateName=soumik-helm-delegate \
  --set accountId=n1yjV_FdQ9GBlBkidw \
  --set delegateToken=MGI1MjkzMzQzNjNTMzNzdhMThlZDY= \
  --set managerEndpoint=https://app.harness.io \
  --set delegateDockerImage=us-docker.pkg.dev/gar-prod-setup/harness-public/harness/delegate:25.08.86503 \
  --set replicas=1 \
  --set upgrader.enabled=true --set upgrader.schedule="* * * * *"
```