### PR TITLE
Allow for custom job names for the upgrader

### DIFF
--- a/harness-delegate-ng/templates/_helpers.tpl
+++ b/harness-delegate-ng/templates/_helpers.tpl
@@ -117,6 +117,24 @@ Define the delegate token name
 {{- end }}
 
 {{/*
+Compute the upgrader job name with 52-character limit validation.
+CronJob names must be <= 52 characters because Kubernetes appends up to 11 characters
+for Job names created from CronJobs (total must be <= 63).
+*/}}
+{{- define "harness-delegate-ng.upgraderJobName" -}}
+{{- $name := "" -}}
+{{- if .Values.upgrader.jobName -}}
+{{- $name = .Values.upgrader.jobName -}}
+{{- else -}}
+{{- $name = printf "%s-upgrader-job" (include "harness-delegate-ng.fullname" .) -}}
+{{- end -}}
+{{- if gt (len $name) 52 -}}
+{{- fail (printf "upgrader job name '%s' is %d characters, which exceeds the 52-character limit. CronJob names must be <= 52 characters because Kubernetes appends up to 11 characters for generated Job names. Set .Values.upgrader.jobName to a shorter name." $name (len $name)) -}}
+{{- end -}}
+{{- $name -}}
+{{- end -}}
+
+{{/*
 Define the upgrader token name
 */}}
 {{- define "harness-delegate-ng.upgraderDelegateToken" -}}

--- a/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
+++ b/harness-delegate-ng/templates/upgrader/upgraderJob.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     {{- include "harness-delegate-ng.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  name: {{ template "harness-delegate-ng.fullname" . }}-upgrader-job
+  name: {{ include "harness-delegate-ng.upgraderJobName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   schedule: {{ .Values.upgrader.schedule | quote }}

--- a/harness-delegate-ng/values.yaml
+++ b/harness-delegate-ng/values.yaml
@@ -140,6 +140,10 @@ upgrader:
     # repository: null
     # tag: null
   
+  # Custom name for the upgrader CronJob. Must be <= 52 characters.
+  # If not set, defaults to "{delegateName}-upgrader-job"
+  jobName: ""
+
   # Schedule for the upgrader cronjob (cron format)
   schedule: "0 */1 * * *"
 


### PR DESCRIPTION
This pull request introduces a configurable and validated job name for the upgrader CronJob in the `harness-delegate-ng` Helm chart. The main goal is to prevent deployment failures due to Kubernetes' name length restrictions by enforcing a 52-character limit and providing clear error messages if exceeded. Users can now optionally set a custom job name via values.

**Upgrader CronJob name validation and configuration:**

* Added a new Helm template helper `harness-delegate-ng.upgraderJobName` that computes the upgrader CronJob name, validates it against the 52-character limit, and fails with a descriptive error if exceeded.
* Updated the `upgraderJob.yaml` resource to use the new helper for the CronJob name, ensuring the validation is applied during template rendering.
* Introduced a new `jobName` field under `upgrader` in `values.yaml`, allowing users to optionally provide a custom name for the upgrader CronJob. The documentation notes the character limit and default behavior.


For testing I did the following:
* Ran `helm template --dry-run` with default values, worked as intended.
* Ran `helm template -f custom1.yaml` with a custom job name, worked as intended
* Ran `helm template -f custom2.yaml` with a custom job name that would exceed the character limit, helm returned an error as expected
* Ran `helm template -f custom3.yaml` with a delegate name that would cause the auto-upgrader to exceed the character limit, helm returned an error as expected.